### PR TITLE
fix: exclude service start on usb

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,3 +32,4 @@
     enabled: yes
     state: started
   become: true
+  tags: usb


### PR DESCRIPTION
Allow script to run on USB where you cant restart services